### PR TITLE
fix: resolve react-icons barrel optimization failure in CI

### DIFF
--- a/components/projects-section.tsx
+++ b/components/projects-section.tsx
@@ -9,9 +9,10 @@ import { FaGithub as Github } from 'react-icons/fa';
 import Image from 'next/image';
 import Link from 'next/link';
 import { projects, textContent } from '@/constants';
+import type { Project } from '@/constants/projects';
 
 interface ProjectsSectionProps {
-  projects?: any[];
+  projects?: Project[];
   showViewAllButton?: boolean;
 }
 

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -9,6 +9,9 @@ const nextConfig = {
   images: {
     unoptimized: true,
   },
+  experimental: {
+    optimizePackageImports: ['react-icons/si', 'react-icons/fa', 'react-icons/hi2', 'react-icons/hi'],
+  },
 }
 
 export default nextConfig

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "react": "^19",
     "react-dom": "^19",
     "react-google-recaptcha": "^3.1.0",
-    "react-icons": "^5.5.0",
+    "react-icons": "5.5.0",
     "tailwind-merge": "^2.5.5",
     "tailwindcss-animate": "^1.0.7"
   },


### PR DESCRIPTION
Next.js 15 applies barrel optimization to large index files like react-icons/si. Without explicit configuration this optimization produces a __barrel_optimize__ virtual module that fails to resolve certain icon exports (SiAmazon, SiAmazondynamodb) in the pnpm CI environment.

- Add experimental.optimizePackageImports for react-icons sub-packages (si, fa, hi2, hi) so Next.js handles their barrel imports correctly
- Pin react-icons to exact version 5.5.0 (remove ^ range) to ensure npm and pnpm resolve identical icons and type declarations; the near-empty pnpm-lock.yaml was allowing pnpm to resolve a different version than npm 5.5.0 (which was verified locally)
- Fix ProjectsSectionProps.projects: any[] -> Project[] (pre-existing main bug that now surfaces since ignoreBuildErrors was removed)