### PR TITLE
feat: backend API integration with ISR and en-US/pt-BR locale support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,9 +34,13 @@ EMAIL_PASSWORD=
 EMAIL_FROM=
 EMAIL_TO=
 NEXT_PUBLIC_CALENDAR_URL=   # Google Calendar scheduling link shown in the contact section
+NEXT_PUBLIC_API_URL=        # FastAPI backend URL (e.g. https://portfolio-api.railway.app)
+                             # Omit to use local TypeScript constants as fallback
+REVALIDATE_SECRET=          # Token for POST /api/revalidate (on-demand ISR cache flush, optional)
 ```
 
 reCAPTCHA and email are optional — the contact form degrades gracefully if these are absent.
+`NEXT_PUBLIC_API_URL` is also optional — all pages fall back to local TypeScript constants when it is absent.
 
 ## Architecture
 
@@ -64,6 +68,10 @@ Dark/light mode via `next-themes` with `attribute="class"`. All colors are CSS v
 ### Contact form flow
 
 `ContactForm` (client component) → `POST /api/contact` (route handler) → reCAPTCHA verification → Nodemailer SMTP. The API checks env vars at runtime; if reCAPTCHA keys are missing it skips verification rather than failing.
+
+### API layer (`lib/api.ts`)
+
+Server-only module (imports `server-only`). When `NEXT_PUBLIC_API_URL` is set, all portfolio content is fetched from the FastAPI backend at build/request time with ISR revalidation (1-hour TTL). Falls back to local constants if the env var is missing or the request fails. Never import `lib/api.ts` in a `'use client'` component.
 
 ### Image handling
 

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import { Timeline } from '@/components/timeline';
 import { SectionWrapper } from '@/components/section-wrapper';
-import { workExperiences, educationExperiences } from '@/constants';
+import { getWorkExperiences, getEducationExperiences } from '@/lib/api';
 
 export const metadata: Metadata = {
   title: 'About',
@@ -46,7 +46,11 @@ export const metadata: Metadata = {
   }
 };
 
-export default function AboutPage() {
+export default async function AboutPage() {
+  const [workExperiences, educationExperiences] = await Promise.all([
+    getWorkExperiences(),
+    getEducationExperiences(),
+  ]);
   return (
     <>
       {/* Structured Data */}

--- a/app/api/revalidate/route.ts
+++ b/app/api/revalidate/route.ts
@@ -1,0 +1,13 @@
+import { revalidatePath } from 'next/cache';
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function POST(request: NextRequest) {
+  if (request.headers.get('x-revalidate-token') !== process.env.REVALIDATE_SECRET) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  ['/', '/projects', '/courses', '/certifications', '/about'].forEach((path) =>
+    revalidatePath(path)
+  );
+  return NextResponse.json({ revalidated: true, timestamp: Date.now() });
+}

--- a/app/certifications/page.tsx
+++ b/app/certifications/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import { CertificatesSection } from '@/components/certificates-section';
 import { SectionWrapper } from '@/components/section-wrapper';
-import { certificatesData } from '@/constants';
+import { getCertificates } from '@/lib/api';
 import type { Certificate } from '@/constants/certificates';
 
 export const metadata: Metadata = {
@@ -47,7 +47,8 @@ export const metadata: Metadata = {
   }
 };
 
-export default function CertificationsPage() {
+export default async function CertificationsPage() {
+  const certificatesData = await getCertificates();
   return (
     <>
       {/* Structured Data */}

--- a/app/courses/page.tsx
+++ b/app/courses/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import { CoursesSection } from '@/components/courses-section';
 import { SectionWrapper } from '@/components/section-wrapper';
-import { coursesData } from '@/constants';
+import { getCourses } from '@/lib/api';
 import type { Course } from '@/constants/courses';
 
 export const metadata: Metadata = {
@@ -48,7 +48,8 @@ export const metadata: Metadata = {
   }
 };
 
-export default function CoursesPage() {
+export default async function CoursesPage() {
+  const coursesData = await getCourses();
   return (
     <>
       {/* Structured Data */}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,19 +4,19 @@ import { SkillsOverviewSection } from '@/components/skills-overview-section';
 import { ProjectsSection } from '@/components/projects-section';
 import { ContactSection } from '@/components/contact-section';
 import { SectionWrapper } from '@/components/section-wrapper';
-import {
-  certificatesData,
-  coursesData,
-  jsonLd,
-  metadata,
-  projects
-} from '@/constants';
+import { jsonLd, metadata } from '@/constants';
+import { getProjects, getCourses, getCertificates } from '@/lib/api';
 import { CoursesSection } from '@/components/courses-section';
 import { CertificatesSection } from '@/components/certificates-section';
 
 export { metadata };
 
-export default function HomePage() {
+export default async function HomePage() {
+  const [projects, coursesData, certificatesData] = await Promise.all([
+    getProjects(),
+    getCourses(),
+    getCertificates(),
+  ]);
   return (
     <>
       <script

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import { ProjectsSection } from '@/components/projects-section';
 import { SectionWrapper } from '@/components/section-wrapper';
-import { projects } from '@/constants';
+import { getProjects } from '@/lib/api';
 import type { Project } from '@/constants/projects';
 
 export const metadata: Metadata = {
@@ -48,7 +48,8 @@ export const metadata: Metadata = {
   }
 };
 
-export default function ProjectsPage() {
+export default async function ProjectsPage() {
+  const projects = await getProjects();
   return (
     <>
       {/* Structured Data */}

--- a/components/locale-provider.tsx
+++ b/components/locale-provider.tsx
@@ -32,6 +32,7 @@ export function LocaleProvider({ children }: { children: React.ReactNode }) {
   const setLocale = (l: Locale) => {
     setLocaleState(l);
     localStorage.setItem('portfolio-locale', l);
+    document.cookie = `portfolio-locale=${l}; path=/; max-age=31536000; SameSite=Lax`;
   };
 
   return (

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,0 +1,59 @@
+import 'server-only';
+import { cookies } from 'next/headers';
+
+import { projects as projectsFallback } from '@/constants/projects';
+import { coursesData as coursesFallback } from '@/constants/courses';
+import { certificatesData as certificatesFallback } from '@/constants/certificates';
+import {
+  workExperiences as workFallback,
+  educationExperiences as educationFallback,
+} from '@/constants/experience';
+import type { Project } from '@/constants/projects';
+import type { Course } from '@/constants/courses';
+import type { Certificate } from '@/constants/certificates';
+import type { WorkExperience, EducationExperience } from '@/constants/experience';
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL;
+
+async function getLocale(): Promise<string> {
+  const cookieStore = await cookies();
+  const value = cookieStore.get('portfolio-locale')?.value;
+  return value === 'pt' ? 'pt' : 'en';
+}
+
+async function apiFetch<T>(path: string, fallback: T): Promise<T> {
+  if (!API_URL) return fallback;
+  const locale = await getLocale();
+  const url = `${API_URL}${path}?locale=${locale}`;
+  try {
+    const res = await fetch(url, { next: { revalidate: 3600 } });
+    if (!res.ok) {
+      console.warn(`[api] ${path} → ${res.status}, using fallback`);
+      return fallback;
+    }
+    return res.json() as Promise<T>;
+  } catch (err) {
+    console.warn(`[api] ${path} fetch failed:`, err);
+    return fallback;
+  }
+}
+
+export async function getProjects(): Promise<Project[]> {
+  return apiFetch<Project[]>('/api/projects', projectsFallback);
+}
+
+export async function getCourses(): Promise<Course[]> {
+  return apiFetch<Course[]>('/api/courses', coursesFallback);
+}
+
+export async function getCertificates(): Promise<Certificate[]> {
+  return apiFetch<Certificate[]>('/api/certificates', certificatesFallback);
+}
+
+export async function getWorkExperiences(): Promise<WorkExperience[]> {
+  return apiFetch<WorkExperience[]>('/api/work-experiences', workFallback);
+}
+
+export async function getEducationExperiences(): Promise<EducationExperience[]> {
+  return apiFetch<EducationExperience[]>('/api/education-experiences', educationFallback);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "igorhsandrade-portfolio-project",
-  "version": "1.2.1",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "igorhsandrade-portfolio-project",
-      "version": "1.2.1",
+      "version": "1.6.0",
       "dependencies": {
         "@radix-ui/react-label": "2.1.1",
         "@radix-ui/react-slot": "1.1.1",
@@ -16,13 +16,15 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "embla-carousel-react": "8.5.1",
-        "next": "15.2.4",
+        "next": "15.2.8",
         "next-themes": "latest",
         "nodemailer": "^7.0.3",
         "react": "^19",
+        "react-country-flag": "^3.1.0",
         "react-dom": "^19",
         "react-google-recaptcha": "^3.1.0",
-        "react-icons": "^5.5.0",
+        "react-icons": "5.5.0",
+        "server-only": "^0.0.1",
         "tailwind-merge": "^2.5.5",
         "tailwindcss-animate": "^1.0.7"
       },
@@ -458,17 +460,19 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.2.4",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.2.4.tgz",
-      "integrity": "sha512-+SFtMgoiYP3WoSswuNmxJOCwi06TdWE733D+WPjpXIe4LXGULwEaofiiAy6kbS0+XjM5xF5n3lKuBwN2SnqD9g=="
+      "version": "15.2.8",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.2.8.tgz",
+      "integrity": "sha512-TaEsAki14R7BlgywA05t2PFYfwZiNlGUHyIQHVyloXX3y+Dm0HUITe5YwTkjtuOQuDhuuLotNEad4VtnmE11Uw==",
+      "license": "MIT"
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "15.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.2.4.tgz",
-      "integrity": "sha512-1AnMfs655ipJEDC/FHkSr0r3lXBgpqKo4K1kiwfUf3iE68rDFXZ1TtHdMvf7D0hMItgDZ7Vuq3JgNMbt/+3bYw==",
+      "version": "15.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.2.5.tgz",
+      "integrity": "sha512-4OimvVlFTbgzPdA0kh8A1ih6FN9pQkL4nPXGqemEYgk+e7eQhsst/p35siNNqA49eQA6bvKZ1ASsDtu9gtXuog==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -478,12 +482,13 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "15.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.2.4.tgz",
-      "integrity": "sha512-3qK2zb5EwCwxnO2HeO+TRqCubeI/NgCe+kL5dTJlPldV/uwCnUgC7VbEzgmxbfrkbjehL4H9BPztWOEtsoMwew==",
+      "version": "15.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.2.5.tgz",
+      "integrity": "sha512-ohzRaE9YbGt1ctE0um+UGYIDkkOxHV44kEcHzLqQigoRLaiMtZzGrA11AJh2Lu0lv51XeiY1ZkUvkThjkVNBMA==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -493,12 +498,13 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "15.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.2.4.tgz",
-      "integrity": "sha512-HFN6GKUcrTWvem8AZN7tT95zPb0GUGv9v0d0iyuTb303vbXkkbHDp/DxufB04jNVD+IN9yHy7y/6Mqq0h0YVaQ==",
+      "version": "15.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.2.5.tgz",
+      "integrity": "sha512-FMSdxSUt5bVXqqOoZCc/Seg4LQep9w/fXTazr/EkpXW2Eu4IFI9FD7zBDlID8TJIybmvKk7mhd9s+2XWxz4flA==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -508,12 +514,13 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "15.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.2.4.tgz",
-      "integrity": "sha512-Oioa0SORWLwi35/kVB8aCk5Uq+5/ZIumMK1kJV+jSdazFm2NzPDztsefzdmzzpx5oGCJ6FkUC7vkaUseNTStNA==",
+      "version": "15.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.2.5.tgz",
+      "integrity": "sha512-4ZNKmuEiW5hRKkGp2HWwZ+JrvK4DQLgf8YDaqtZyn7NYdl0cHfatvlnLFSWUayx9yFAUagIgRGRk8pFxS8Qniw==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -523,12 +530,13 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "15.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.2.4.tgz",
-      "integrity": "sha512-yb5WTRaHdkgOqFOZiu6rHV1fAEK0flVpaIN2HB6kxHVSy/dIajWbThS7qON3W9/SNOH2JWkVCyulgGYekMePuw==",
+      "version": "15.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.2.5.tgz",
+      "integrity": "sha512-bE6lHQ9GXIf3gCDE53u2pTl99RPZW5V1GLHSRMJ5l/oB/MT+cohu9uwnCK7QUph2xIOu2a6+27kL0REa/kqwZw==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -538,12 +546,13 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "15.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.2.4.tgz",
-      "integrity": "sha512-Dcdv/ix6srhkM25fgXiyOieFUkz+fOYkHlydWCtB0xMST6X9XYI3yPDKBZt1xuhOytONsIFJFB08xXYsxUwJLw==",
+      "version": "15.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.2.5.tgz",
+      "integrity": "sha512-y7EeQuSkQbTAkCEQnJXm1asRUuGSWAchGJ3c+Qtxh8LVjXleZast8Mn/rL7tZOm7o35QeIpIcid6ufG7EVTTcA==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -553,12 +562,13 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "15.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.2.4.tgz",
-      "integrity": "sha512-dW0i7eukvDxtIhCYkMrZNQfNicPDExt2jPb9AZPpL7cfyUo7QSNl1DjsHjmmKp6qNAqUESyT8YFl/Aw91cNJJg==",
+      "version": "15.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.2.5.tgz",
+      "integrity": "sha512-gQMz0yA8/dskZM2Xyiq2FRShxSrsJNha40Ob/M2n2+JGRrZ0JwTVjLdvtN6vCxuq4ByhOd4a9qEf60hApNR2gQ==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -568,12 +578,13 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "15.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.2.4.tgz",
-      "integrity": "sha512-SbnWkJmkS7Xl3kre8SdMF6F/XDh1DTFEhp0jRTj/uB8iPKoU2bb2NDfcu+iifv1+mxQEd1g2vvSxcZbXSKyWiQ==",
+      "version": "15.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.2.5.tgz",
+      "integrity": "sha512-tBDNVUcI7U03+3oMvJ11zrtVin5p0NctiuKmTGyaTIEAVj9Q77xukLXGXRnWxKRIIdFG4OTA2rUVGZDYOwgmAA==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -1768,11 +1779,12 @@
       }
     },
     "node_modules/next": {
-      "version": "15.2.4",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.2.4.tgz",
-      "integrity": "sha512-VwL+LAaPSxEkd3lU2xWbgEOtrM8oedmyhBqaVNmgKB+GvZlCy9rgaEc+y2on0wv+l0oSFqLtYD6dcC1eAedUaQ==",
+      "version": "15.2.8",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.2.8.tgz",
+      "integrity": "sha512-pe2trLKZTdaCuvNER0S9Wp+SP2APf7SfFmyUP9/w1SFA2UqmW0u+IsxCKkiky3n6um7mryaQIlgiDnKrf1ZwIw==",
+      "license": "MIT",
       "dependencies": {
-        "@next/env": "15.2.4",
+        "@next/env": "15.2.8",
         "@swc/counter": "0.1.3",
         "@swc/helpers": "0.5.15",
         "busboy": "1.6.0",
@@ -1787,14 +1799,14 @@
         "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "15.2.4",
-        "@next/swc-darwin-x64": "15.2.4",
-        "@next/swc-linux-arm64-gnu": "15.2.4",
-        "@next/swc-linux-arm64-musl": "15.2.4",
-        "@next/swc-linux-x64-gnu": "15.2.4",
-        "@next/swc-linux-x64-musl": "15.2.4",
-        "@next/swc-win32-arm64-msvc": "15.2.4",
-        "@next/swc-win32-x64-msvc": "15.2.4",
+        "@next/swc-darwin-arm64": "15.2.5",
+        "@next/swc-darwin-x64": "15.2.5",
+        "@next/swc-linux-arm64-gnu": "15.2.5",
+        "@next/swc-linux-arm64-musl": "15.2.5",
+        "@next/swc-linux-x64-gnu": "15.2.5",
+        "@next/swc-linux-x64-musl": "15.2.5",
+        "@next/swc-win32-arm64-msvc": "15.2.5",
+        "@next/swc-win32-x64-msvc": "15.2.5",
         "sharp": "^0.33.5"
       },
       "peerDependencies": {
@@ -2151,6 +2163,18 @@
         "react": ">=16.4.1"
       }
     },
+    "node_modules/react-country-flag": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/react-country-flag/-/react-country-flag-3.1.0.tgz",
+      "integrity": "sha512-JWQFw1efdv9sTC+TGQvTKXQg1NKbDU2mBiAiRWcKM9F1sK+/zjhP2yGmm8YDddWyZdXVkR8Md47rPMJmo4YO5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": ">=16"
+      }
+    },
     "node_modules/react-dom": {
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
@@ -2272,6 +2296,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/server-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
+      "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==",
+      "license": "MIT"
     },
     "node_modules/sharp": {
       "version": "0.33.5",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "react-dom": "^19",
     "react-google-recaptcha": "^3.1.0",
     "react-icons": "5.5.0",
+    "server-only": "^0.0.1",
     "tailwind-merge": "^2.5.5",
     "tailwindcss-animate": "^1.0.7"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       react-icons:
         specifier: 5.5.0
         version: 5.5.0(react@19.2.5)
+      server-only:
+        specifier: ^0.0.1
+        version: 0.0.1
       tailwind-merge:
         specifier: ^2.5.5
         version: 2.6.1
@@ -915,6 +918,9 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  server-only@0.0.1:
+    resolution: {integrity: sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==}
+
   sharp@0.33.5:
     resolution: {integrity: sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
@@ -1680,6 +1686,8 @@ snapshots:
 
   semver@7.7.4:
     optional: true
+
+  server-only@0.0.1: {}
 
   sharp@0.33.5:
     dependencies:


### PR DESCRIPTION
## Summary

- **`lib/api.ts`** — new server-only module that fetches portfolio content (projects, courses, certificates, work/education experiences) from the FastAPI backend with 1-hour ISR cache per locale; falls back silently to local TypeScript constants when `NEXT_PUBLIC_API_URL` is unset or the request fails
- **Five content pages** (`/`, `/projects`, `/courses`, `/certifications`, `/about`) converted to `async` server components — data is fetched at the page level and passed as props to existing client section components (no section component changes needed)
- **Locale cookie** — `LocaleProvider` now sets a `portfolio-locale` cookie alongside `localStorage` so server-side fetches can read the active locale and request `?locale=en` or `?locale=pt` from the API
- **On-demand revalidation** — `POST /api/revalidate` (protected by `REVALIDATE_SECRET`) flushes the ISR fetch cache immediately after a content update in the backend
- **`CLAUDE.md`** updated with new env vars and the `lib/api.ts` architecture note

## How locale works end-to-end

1. User toggles locale → `LocaleProvider` writes `portfolio-locale` to both `localStorage` (for client) and a cookie (for server)
2. Next request hits the server → `lib/api.ts` reads the cookie via `cookies()` from `next/headers`
3. `apiFetch` appends `?locale=en|pt` — the fetch cache keys include the locale, so both languages are cached independently
4. Pages are `○ Static` locally (no `API_URL` set, `cookies()` never reached) and `ƒ Dynamic` on Vercel with `API_URL` set

## Backend

Backend implementation instructions are in `../igorhsandrade-portfolio-backend/INSTRUCTIONS.md` — full FastAPI project spec with bilingual database schema, Pydantic schemas, router pattern, bilingual seed data, Dockerfile, and Railway deployment checklist.

## New environment variables

```
NEXT_PUBLIC_API_URL=    # FastAPI backend URL — omit to use local constants
REVALIDATE_SECRET=      # Token for POST /api/revalidate (optional)
```

## Test plan

- [ ] `npm run build` passes with no type errors
- [ ] Without `NEXT_PUBLIC_API_URL`: all pages render correctly using local constants
- [ ] With `NEXT_PUBLIC_API_URL` set: Network tab shows fetches to the backend; `x-nextjs-cache` shows `HIT` on repeated requests within 1 hour
- [ ] Toggling locale updates the `portfolio-locale` cookie (visible in DevTools → Application → Cookies)
- [ ] API failure: pages fall back silently (set `NEXT_PUBLIC_API_URL` to a non-existent URL to test)
- [ ] `POST /api/revalidate` with correct token returns `{ revalidated: true }`; with wrong token returns 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)