### PR TITLE
fix: localize all hardcoded strings in the skills section

### DIFF
--- a/components/skills-overview-section.tsx
+++ b/components/skills-overview-section.tsx
@@ -16,7 +16,7 @@ export function SkillsOverviewSection() {
               {t.about.skillsTitle}
             </h2>
             <p className="text-lg text-muted-foreground max-w-2xl mx-auto mb-8">
-              Technologies and tools I work with to bring ideas to life
+              {t.about.skillsSubtitle}
             </p>
           </div>
           <SkillsSection skills={skillsData} />

--- a/components/skills-section.tsx
+++ b/components/skills-section.tsx
@@ -72,6 +72,7 @@ import {
 } from 'react-icons/si';
 import { cn } from '@/lib/utils';
 import { Input } from '@/components/ui/input';
+import { useLocale } from '@/components/locale-provider';
 import type {
   Skill,
   SkillIcon,
@@ -250,6 +251,7 @@ const getLevelWidth: LevelStyleFunction = (level) => {
 };
 
 export function SkillsSection({ skills }: SkillsSectionProps): JSX.Element {
+  const { t } = useLocale();
   const skillsByCategory = useMemo((): SkillsByCategory => {
     const grouped = skills.reduce<SkillsByCategory>((acc, skill) => {
       if (!acc[skill.category]) {
@@ -339,13 +341,13 @@ export function SkillsSection({ skills }: SkillsSectionProps): JSX.Element {
                 getBadgeColorClasses(skill.level)
               )}
             >
-              {skill.level}
+              {t.skills.levels[skill.level]}
             </Badge>
           </div>
           <div className="flex items-center justify-between gap-3">
             <div className="text-xs text-muted-foreground flex items-center gap-1">
               <HiCalendar className="w-3 h-3" />
-              {skill.years} years
+              {skill.years} {skill.years === 1 ? t.skills.year : t.skills.years}
             </div>
             <div className="flex-1 max-w-24">
               <div className="w-full bg-muted rounded-full h-2">
@@ -371,7 +373,7 @@ export function SkillsSection({ skills }: SkillsSectionProps): JSX.Element {
               <h4 className="font-medium">{skill.name}</h4>
               <div className="text-xs text-muted-foreground flex items-center gap-1">
                 <HiCalendar className="w-3 h-3" />
-                {skill.years} years
+                {skill.years} {skill.years === 1 ? t.skills.year : t.skills.years}
               </div>
             </div>
           </div>
@@ -386,7 +388,7 @@ export function SkillsSection({ skills }: SkillsSectionProps): JSX.Element {
                     getBadgeColorClasses(skill.level)
                   )}
                 >
-                  {skill.level}
+                  {t.skills.levels[skill.level]}
                 </Badge>
               </div>
               <div className="w-full bg-muted rounded-full h-2">
@@ -411,7 +413,7 @@ export function SkillsSection({ skills }: SkillsSectionProps): JSX.Element {
       <div className="relative mb-6">
         <HiMagnifyingGlass className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground w-4 h-4" />
         <Input
-          placeholder="Search skills..."
+          placeholder={t.skills.searchPlaceholder}
           value={searchTerm}
           onChange={(e) => setSearchTerm(e.target.value)}
           className="pl-10 pr-10"
@@ -428,13 +430,16 @@ export function SkillsSection({ skills }: SkillsSectionProps): JSX.Element {
 
       {searchTerm && (
         <div className="mb-4 text-sm text-muted-foreground">
-          Found {totalFilteredSkills} skill
-          {totalFilteredSkills !== 1 ? 's' : ''} matching "{searchTerm}"
+          {t.skills.found} {totalFilteredSkills}{' '}
+          {totalFilteredSkills !== 1 ? t.skills.skillsPlural : t.skills.skill}{' '}
+          {t.skills.matching} &ldquo;{searchTerm}&rdquo;
           {totalFilteredSkills > 0 && (
             <span className="ml-2 text-teal-600">
-              • Showing results in{' '}
-              {Object.keys(filteredSkillsByCategory).length} categor
-              {Object.keys(filteredSkillsByCategory).length !== 1 ? 'ies' : 'y'}
+              &bull; {t.skills.showingIn}{' '}
+              {Object.keys(filteredSkillsByCategory).length}{' '}
+              {Object.keys(filteredSkillsByCategory).length !== 1
+                ? t.skills.categoriesWord
+                : t.skills.categoryWord}
             </span>
           )}
         </div>
@@ -500,7 +505,7 @@ export function SkillsSection({ skills }: SkillsSectionProps): JSX.Element {
 
                     {/* Text */}
                     <span className="whitespace-nowrap md:text-center">
-                      {category}
+                      {t.skills.categories[category]}
                     </span>
 
                     {/* Badge - only on desktop or when searching */}
@@ -545,20 +550,16 @@ export function SkillsSection({ skills }: SkillsSectionProps): JSX.Element {
                     {searchTerm ? (
                       <>
                         <div className="mb-2">
-                          No skills found matching "{searchTerm}" in {category}
+                          {t.skills.noResultsFor} &ldquo;{searchTerm}&rdquo; {t.skills.inCategory} {t.skills.categories[category]}
                         </div>
                         <div className="text-sm">
-                          Try a different search term or browse other categories
+                          {t.skills.tryDifferent}
                         </div>
                       </>
                     ) : (
                       <>
-                        <div className="mb-2">
-                          No skills in this category yet
-                        </div>
-                        <div className="text-sm">
-                          Skills will be added as I learn new technologies
-                        </div>
+                        <div className="mb-2">{t.skills.noSkills}</div>
+                        <div className="text-sm">{t.skills.willBeAdded}</div>
                       </>
                     )}
                   </div>

--- a/locales/en.ts
+++ b/locales/en.ts
@@ -42,6 +42,7 @@ export const en = {
         "I believe in writing clean, maintainable code and following best practices. I'm always learning new technologies and staying up-to-date with industry trends to deliver the best solutions."
     },
     skillsTitle: 'Skills & Technologies',
+    skillsSubtitle: 'Technologies and tools I work with to bring ideas to life',
     coursesTitle: 'Professional Development',
     coursesSubtitle:
       'Continuously learning and mastering new technologies through comprehensive courses and specializations.',
@@ -141,6 +142,36 @@ export const en = {
       termsOfService: 'Terms of Service',
       builtWith: 'Built with Next.js & Tailwind CSS'
     }
+  },
+
+  skills: {
+    searchPlaceholder: 'Search skills...',
+    year: 'year',
+    years: 'years',
+    categories: {
+      Languages: 'Languages',
+      Technologies: 'Technologies',
+      Data: 'Data',
+      Tools: 'Tools'
+    },
+    levels: {
+      Expert: 'Expert',
+      Advanced: 'Advanced',
+      Intermediate: 'Intermediate',
+      Beginner: 'Beginner'
+    },
+    found: 'Found',
+    skill: 'skill',
+    skillsPlural: 'skills',
+    matching: 'matching',
+    showingIn: 'Showing results in',
+    categoryWord: 'category',
+    categoriesWord: 'categories',
+    noResultsFor: 'No skills found matching',
+    inCategory: 'in',
+    tryDifferent: 'Try a different search term or browse other categories',
+    noSkills: 'No skills in this category yet',
+    willBeAdded: 'Skills will be added as I learn new technologies'
   },
 
   common: {

--- a/locales/pt.ts
+++ b/locales/pt.ts
@@ -39,6 +39,7 @@ export const pt: TextContent = {
         'Acredito em escrever código limpo e manutenível seguindo boas práticas. Estou sempre aprendendo novas tecnologias e me mantendo atualizado com as tendências do setor para entregar as melhores soluções.'
     },
     skillsTitle: 'Habilidades & Tecnologias',
+    skillsSubtitle: 'Tecnologias e ferramentas com as quais trabalho para dar vida às ideias',
     coursesTitle: 'Desenvolvimento Profissional',
     coursesSubtitle:
       'Aprendendo e dominando continuamente novas tecnologias através de cursos e especializações abrangentes.',
@@ -138,6 +139,36 @@ export const pt: TextContent = {
       termsOfService: 'Termos de Serviço',
       builtWith: 'Desenvolvido com Next.js & Tailwind CSS'
     }
+  },
+
+  skills: {
+    searchPlaceholder: 'Buscar habilidades...',
+    year: 'ano',
+    years: 'anos',
+    categories: {
+      Languages: 'Linguagens',
+      Technologies: 'Tecnologias',
+      Data: 'Dados',
+      Tools: 'Ferramentas'
+    },
+    levels: {
+      Expert: 'Especialista',
+      Advanced: 'Avançado',
+      Intermediate: 'Intermediário',
+      Beginner: 'Iniciante'
+    },
+    found: 'Encontrado',
+    skill: 'habilidade',
+    skillsPlural: 'habilidades',
+    matching: 'correspondente a',
+    showingIn: 'Mostrando resultados em',
+    categoryWord: 'categoria',
+    categoriesWord: 'categorias',
+    noResultsFor: 'Nenhuma habilidade encontrada para',
+    inCategory: 'em',
+    tryDifferent: 'Tente um termo diferente ou navegue por outras categorias',
+    noSkills: 'Nenhuma habilidade nesta categoria ainda',
+    willBeAdded: 'Habilidades serão adicionadas conforme aprendo novas tecnologias'
   },
 
   common: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       react-icons:
         specifier: 5.5.0
         version: 5.5.0(react@19.2.5)
+      server-only:
+        specifier: ^0.0.1
+        version: 0.0.1
       tailwind-merge:
         specifier: ^2.5.5
         version: 2.6.1
@@ -915,6 +918,9 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  server-only@0.0.1:
+    resolution: {integrity: sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==}
+
   sharp@0.33.5:
     resolution: {integrity: sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
@@ -1680,6 +1686,8 @@ snapshots:
 
   semver@7.7.4:
     optional: true
+
+  server-only@0.0.1: {}
 
   sharp@0.33.5:
     dependencies:


### PR DESCRIPTION
## Summary

- Add `skills` i18n keys to both `en` and `pt` locales: search placeholder, category names (Languages/Technologies/Data/Tools), proficiency levels (Expert/Advanced/Intermediate/Beginner), year/years label, and all search result/empty-state messages
- Wire `skills-section.tsx` and `skills-overview-section.tsx` to `useLocale` so all text responds to the PT/EN toggle
- Fix "1 years" grammar bug — now uses singular (`year`/`ano`) or plural based on `skill.years`

## Test plan

- [ ] Toggle locale to PT and verify the Skills section subtitle, search placeholder, category tabs, level badges, and "X anos" all render in Portuguese
- [ ] Toggle back to EN and verify English strings are restored
- [ ] Search for a skill (e.g. "react") and verify the result count message is localized
- [ ] Verify a skill with 1 year of experience shows "1 year" / "1 ano" (not "1 years")

🤖 Generated with [Claude Code](https://claude.com/claude-code)